### PR TITLE
Specify RYE_VERSION and RYE_INSTALL_OPTIONS in shell env.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,12 +3,14 @@ description: Installs [Rye](rye.astral.sh) on Github Ubuntu Runners.
 inputs:
   rye-version:
     description: The version of `Rye` to install
-    default: 'latest'
+    default: "latest"
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - env:
-        INPUT_RYE_VERSION: ${{ inputs.rye-version }}
+        RYE_VERSION: "${{ inputs.rye-version }}"
+        RYE_INSTALL_OPTION: "--yes"
     - run: |
-        curl -sSf https://rye.astral.sh/get | RYE_VERSION="$INPUT_RYE_VERSION" RYE_INSTALL_OPTION="--yes" bash
+        curl -sSf https://rye.astral.sh/get
+        source $HOME/.rye/env
       shell: bash


### PR DESCRIPTION
Also source $HOME/.rye/env after installation.